### PR TITLE
Fix "CheckedExceptionMapperTest.testThrowException"

### DIFF
--- a/server/openejb-cxf-rs/src/main/java/org/apache/openejb/server/cxf/rs/CxfRsHttpListener.java
+++ b/server/openejb-cxf-rs/src/main/java/org/apache/openejb/server/cxf/rs/CxfRsHttpListener.java
@@ -1167,9 +1167,11 @@ public class CxfRsHttpListener implements RsHttpListener {
         final boolean ignoreAutoProviders = "true".equalsIgnoreCase(SystemInstance.get().getProperty(key, serviceConfiguration.getProperties().getProperty(key, "false")));
         final List<Object> additionalProviders = new ArrayList<Object>(ignoreAutoProviders ? Collections.EMPTY_LIST : givenAdditionalProviders);
 
-        for (final Class<?> clzz : application.getClasses()) {
-            if (isProvider(clzz) && !additionalProviders.contains(clzz)) {
-                additionalProviders.add(clzz);
+        if(application != null) {
+            for (final Class<?> clzz : application.getClasses()) {
+                if (isProvider(clzz) && !additionalProviders.contains(clzz)) {
+                    additionalProviders.add(clzz);
+                }
             }
         }
 


### PR DESCRIPTION
Many ways to wrap a null application. So make sure we don't try to access it's classes...